### PR TITLE
dotenv app loader & TY template fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'dotenv-rails'
 end
+
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
@@ -55,6 +57,7 @@ group :production do
   gem 'pg'
   gem 'rails_12factor'
 end
+
 # Run against the latest stable release
 group :development, :test do
   gem 'rspec-rails', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    dotenv (2.7.2)
+    dotenv-rails (2.7.2)
+      dotenv (= 2.7.2)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
@@ -261,6 +265,7 @@ DEPENDENCIES
   cancancan (~> 1.10)
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   factory_bot
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/views/payments/thank_you.html.erb
+++ b/app/views/payments/thank_you.html.erb
@@ -1,7 +1,2 @@
-
 Thank you for purchasing <%= @product.name %>
 <%= link_to "Go Home", root_path %>
-=======
-Thank you for purchasing <%= @product.name %>
-<%= link_to "Go Home", root_path %>
-

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,14 +12,14 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
 
-require "dotenv/load"
-
 # require "rails/test_unit/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-
+if ['development', 'test'].include? ENV['RAILS_ENV']
+  Dotenv::Railtie.load
+end
 
 module JeffsApp
   class Application < Rails::Application


### PR DESCRIPTION
fixing dotenv in development and production. 

Your heroku app is most likely breaking because it's trying to load a gem that only bundles in development and test. We can conditionally run the Dotenv loader if we're in development or test to resolve this issue.